### PR TITLE
FIX: Audit call giving NaN in description

### DIFF
--- a/controllers/trelloController.ts
+++ b/controllers/trelloController.ts
@@ -141,7 +141,7 @@ function createCardInfo(callReq: RequestCall): [CardData, Checks] {
 		desc:
 			`## Cliente: **${Call.client}**\n---\n` +
 			`**Tablets:** ${Call.tablets[0] || 0}\n` +
-			`**Termovisores:** ${Call.thermal.reduce((acc, cur) => {return acc + parseInt(cur)}, 0)}\n` +
+			`**Termovisores:** ${Call.thermal.reduce((acc, cur) => {return acc + parseInt(cur || '0')}, 0)}\n` +
 			`**Trena Digital:** ${Call.digital_measure[0] || 0}\n` +
 			`**Elétrica:**\n${Call.electric.map((item: string) => " " + item)}\n` +
 			`**Civil:**\n${Call.civil.map((item: string) => " " + item)}\n` +


### PR DESCRIPTION
Every time an enginner forget to select 0 in the forms the description of the card Trello gives "NaN", fixing this.